### PR TITLE
Connected user profiles in firebase firestore to app views

### DIFF
--- a/Team10_JournalApp.xcodeproj/project.pbxproj
+++ b/Team10_JournalApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		DAAD574F2CF1423B00BCA39F /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = DAAD574E2CF1423B00BCA39F /* FirebaseFirestore */; };
 		DAB7F4232CED9821002E77DE /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = DAB7F4222CED9821002E77DE /* FirebaseAuth */; };
 		DABD3CCD2CD56ADF00D090B4 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = DABD3CCC2CD56ADF00D090B4 /* FirebaseAnalytics */; };
 /* End PBXBuildFile section */
@@ -30,6 +31,7 @@
 			files = (
 				DABD3CCD2CD56ADF00D090B4 /* FirebaseAnalytics in Frameworks */,
 				DAB7F4232CED9821002E77DE /* FirebaseAuth in Frameworks */,
+				DAAD574F2CF1423B00BCA39F /* FirebaseFirestore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -82,6 +84,7 @@
 			packageProductDependencies = (
 				DABD3CCC2CD56ADF00D090B4 /* FirebaseAnalytics */,
 				DAB7F4222CED9821002E77DE /* FirebaseAuth */,
+				DAAD574E2CF1423B00BCA39F /* FirebaseFirestore */,
 			);
 			productName = Team10_JournalApp;
 			productReference = DA0874132CB34C9A008EC76D /* Team10_JournalApp.app */;
@@ -361,6 +364,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		DAAD574E2CF1423B00BCA39F /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DABD3CCB2CD56ADF00D090B4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
 		DAB7F4222CED9821002E77DE /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = DABD3CCB2CD56ADF00D090B4 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/Team10_JournalApp/AppViewController.swift
+++ b/Team10_JournalApp/AppViewController.swift
@@ -22,17 +22,6 @@ class AppViewController: ObservableObject {
         
         self.loggedIn = authUser != nil
         
-        if let signedInUser = authUser {
-            Task {
-                do {
-                    let profile = try await UserManager.shared.getUser(userId: signedInUser.uid)
-                    self.loadedUserProfile = profile
-                } catch {
-                    print("SYSTEM: signed in but failed to load user profile.")
-                }
-            }
-        }
-        
         if !loggedIn {
             viewSignUpFlag = redirectToSignInIfNoAuth ? false : viewSignUpFlag
             print("SYSTEM: No authenticated user found.")

--- a/Team10_JournalApp/AppViewController.swift
+++ b/Team10_JournalApp/AppViewController.swift
@@ -14,6 +14,8 @@ class AppViewController: ObservableObject {
     @Published var loggedIn: Bool = false
     @Published var viewSignUpFlag: Bool = false
     
+    @Published var loadedUserProfile: UserProfile?
+    
     func certifyAuthStatus(redirectToSignInIfNoAuth: Bool = false) {
         let authUser = try? AuthenticationManager.shared.getAuthenticatedUser()
         print(authUser ?? "authUser: NONE")

--- a/Team10_JournalApp/AppViewController.swift
+++ b/Team10_JournalApp/AppViewController.swift
@@ -10,13 +10,15 @@ import SwiftUI
 
 let isIphone16ProMaxPortrait: Bool = UIScreen.main.bounds.height == 956.0
 
+@MainActor
 class AppViewController: ObservableObject {
     @Published var loggedIn: Bool = false
     @Published var viewSignUpFlag: Bool = false
     
     @Published var loadedUserProfile: UserProfile?
     
-    func certifyAuthStatus(redirectToSignInIfNoAuth: Bool = false) {
+    @discardableResult
+    func certifyAuthStatus(redirectToSignInIfNoAuth: Bool = false) -> AuthDataResultModel? {
         let authUser = try? AuthenticationManager.shared.getAuthenticatedUser()
         print(authUser ?? "authUser: NONE")
         
@@ -26,6 +28,8 @@ class AppViewController: ObservableObject {
             viewSignUpFlag = redirectToSignInIfNoAuth ? false : viewSignUpFlag
             print("SYSTEM: No authenticated user found.")
         }
+        
+        return authUser
     }
     
 }

--- a/Team10_JournalApp/AppViewController.swift
+++ b/Team10_JournalApp/AppViewController.swift
@@ -22,6 +22,17 @@ class AppViewController: ObservableObject {
         
         self.loggedIn = authUser != nil
         
+        if let signedInUser = authUser {
+            Task {
+                do {
+                    let profile = try await UserManager.shared.getUser(userId: signedInUser.uid)
+                    self.loadedUserProfile = profile
+                } catch {
+                    print("SYSTEM: signed in but failed to load user profile.")
+                }
+            }
+        }
+        
         if !loggedIn {
             viewSignUpFlag = redirectToSignInIfNoAuth ? false : viewSignUpFlag
             print("SYSTEM: No authenticated user found.")

--- a/Team10_JournalApp/Models/Firebase/AuthDataResultModel.swift
+++ b/Team10_JournalApp/Models/Firebase/AuthDataResultModel.swift
@@ -10,12 +10,12 @@ import FirebaseAuth
 
 struct AuthDataResultModel {
     let uid: String
-    let email: String?
+    let email: String
     let photoUrl: String?
     
     init(user: User) {
         self.uid = user.uid
-        self.email = user.email
+        self.email = user.email ?? "NONE"
         self.photoUrl = user.photoURL?.absoluteString
     }
 }

--- a/Team10_JournalApp/Models/Firebase/UserProfileModel.swift
+++ b/Team10_JournalApp/Models/Firebase/UserProfileModel.swift
@@ -1,0 +1,66 @@
+//
+//  UserProfileModel.swift
+//  Team10_JournalApp
+//
+//  Created by ujwal joshi on 11/22/24.
+//
+
+import Foundation
+import FirebaseFirestore
+
+struct UserProfile: Codable {
+    let userId: String
+    let email: String
+    let displayName: String
+    let dateCreated: Date
+    let photoURL: String?
+    let friendUserIDs: [String]
+    
+    init(authUser: AuthDataResultModel) {
+        self.userId = authUser.uid
+        self.email = authUser.email
+        self.displayName = authUser.email
+        self.dateCreated = Date()
+        self.photoURL = authUser.photoUrl
+        self.friendUserIDs = []
+    }
+    
+    init(userId: String, email: String, displayName: String, dateCreated: Date, photoURL: String?, friendUserIDs: [String]) {
+        self.userId = userId
+        self.email = email
+        self.displayName = displayName
+        self.dateCreated = dateCreated
+        self.photoURL = photoURL
+        self.friendUserIDs = friendUserIDs
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case email = "email"
+        case displayName = "display_name"
+        case dateCreated = "date_created"
+        case photoURL = "photo_url"
+        case friendUserIDs = "friend_user_ids"
+    }
+    
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.userId = try container.decode(String.self, forKey: .userId)
+        self.email = try container.decode(String.self, forKey: .email)
+        self.displayName = try container.decode(String.self, forKey: .displayName)
+        self.dateCreated = try container.decode(Date.self, forKey: .dateCreated)
+        self.photoURL = try container.decodeIfPresent(String.self, forKey: .photoURL)
+        self.friendUserIDs = try container.decode([String].self, forKey: .friendUserIDs)
+    }
+    
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(self.userId, forKey: .userId)
+        try container.encodeIfPresent(self.email, forKey: .email)
+        try container.encodeIfPresent(self.displayName, forKey: .displayName)
+        try container.encodeIfPresent(self.dateCreated, forKey: .dateCreated)
+        try container.encodeIfPresent(self.photoURL, forKey: .photoURL)
+        try container.encodeIfPresent(self.friendUserIDs, forKey: .friendUserIDs)
+    }
+}

--- a/Team10_JournalApp/UserContentView.swift
+++ b/Team10_JournalApp/UserContentView.swift
@@ -19,7 +19,7 @@ struct UserContentView: View {
         VStack {
             TabView(selection: $selectedTab) {
                 Tab("Home", systemImage: "house", value: .Home) {
-                    HomeView()
+                    HomeView(appController: appController)
                 }
                 
                 Tab("Journal", systemImage: "book", value: .Journal) {

--- a/Team10_JournalApp/Utilities/Firebase/UserManager.swift
+++ b/Team10_JournalApp/Utilities/Firebase/UserManager.swift
@@ -1,0 +1,20 @@
+//
+//  UserManager.swift
+//  Team10_JournalApp
+//
+//  Created by ujwal joshi on 11/22/24.
+//
+
+import Foundation
+import FirebaseFirestore
+
+final class UserManager {
+    static let shared = UserManager()
+    private init() { }
+    
+    private let userCollection = Firestore.firestore().collection("users")
+    
+    private func userDocument(userId: String) -> DocumentReference {
+        userCollection.document(userId)
+    }
+}

--- a/Team10_JournalApp/Utilities/Firebase/UserManager.swift
+++ b/Team10_JournalApp/Utilities/Firebase/UserManager.swift
@@ -17,4 +17,16 @@ final class UserManager {
     private func userDocument(userId: String) -> DocumentReference {
         userCollection.document(userId)
     }
+    
+    func getUser(userId: String) async throws -> UserProfile {
+        try await userDocument(userId: userId).getDocument(as: UserProfile.self)
+    }
+    
+    func createNewUser(user: UserProfile) async throws {
+        try userDocument(userId: user.userId).setData(from: user, merge: false)
+    }
+    
+    // TODO: update user display name
+    
+    // TODO: update user friends list
 }

--- a/Team10_JournalApp/Utilities/Firebase/UserManager.swift
+++ b/Team10_JournalApp/Utilities/Firebase/UserManager.swift
@@ -26,7 +26,28 @@ final class UserManager {
         try userDocument(userId: user.userId).setData(from: user, merge: false)
     }
     
-    // TODO: update user display name
+    func updateUserDisplayName(userId: String, displayName: String) async throws {
+        let data: [String: Any] = [
+            UserProfile.CodingKeys.displayName.rawValue : displayName
+        ]
+        
+        try await userDocument(userId: userId).updateData(data)
+    }
     
-    // TODO: update user friends list
+    func addFriend(userId: String, friendUserId: String) async throws {
+        let data: [String: Any] = [
+            UserProfile.CodingKeys.friendUserIDs.rawValue: FieldValue.arrayUnion([friendUserId])
+        ]
+        
+        try await userDocument(userId: userId).updateData(data)
+    }
+    
+    func removeFriend(userId: String, friendUserId: String) async throws {
+        let data: [String: Any] = [
+            UserProfile.CodingKeys.friendUserIDs.rawValue: FieldValue.arrayRemove([friendUserId])
+        ]
+        
+        try await userDocument(userId: userId).updateData(data)
+    }
+    
 }

--- a/Team10_JournalApp/ViewModels/SignInViewModel.swift
+++ b/Team10_JournalApp/ViewModels/SignInViewModel.swift
@@ -14,7 +14,7 @@ class SignInViewModel: ObservableObject {
     
     @Published var isShowingSignInFailedAlert: Bool = false
     
-    func signIn(onSignIn: @escaping () -> Void) {
+    func signIn(onSignIn: @escaping (UserProfile) -> Void) {
         guard !email.isEmpty, !password.isEmpty else {
             print("No email or password found")
             return
@@ -24,9 +24,11 @@ class SignInViewModel: ObservableObject {
             do {
                 let userData = try await AuthenticationManager.shared.signInUser(email: email, password: password)
                 print("Sucessfully signed in user: \(email)")
-                print(userData)
                 
-                onSignIn()
+                let userProfile = try await UserManager.shared.getUser(userId: userData.uid)
+                
+                print(userProfile)
+                onSignIn(userProfile)
                 
             } catch {
                 print("Failed to sign in user with error: \(error)")

--- a/Team10_JournalApp/ViewModels/SignUpViewModel.swift
+++ b/Team10_JournalApp/ViewModels/SignUpViewModel.swift
@@ -15,7 +15,7 @@ class SignUpViewModel: ObservableObject {
     
     @Published var isSignUpFailedAlertShowing: Bool = false
     
-    func signUp(onSignUp: @escaping () -> Void) {
+    func signUp(onSignUp: @escaping (UserProfile) -> Void) {
         guard !email.isEmpty, !password.isEmpty, !retypedPassword.isEmpty else {
             print("No email or password found")
             return
@@ -30,9 +30,12 @@ class SignUpViewModel: ObservableObject {
             do {
                 let userData = try await AuthenticationManager.shared.createUser(email: email, password: password)
                 print("Succesfully created user: \(email)")
-                print(userData)
                 
-                onSignUp()
+                let newUser = UserProfile(authUser: userData)
+                try await UserManager.shared.createNewUser(user: newUser)
+                
+                print(newUser)
+                onSignUp(newUser)
                 
             } catch {
                 print("Failed to sign up with error: \(error)")

--- a/Team10_JournalApp/Views/Home/HomeView.swift
+++ b/Team10_JournalApp/Views/Home/HomeView.swift
@@ -13,15 +13,26 @@ struct HomeView: View {
     
     var body: some View {
         AppLayoutContainer(height: 10.0) {
-            Text("CatchUp")
-                .font(.system(size: 30.0))
-                .fontWeight(.heavy)
-                .padding()
+            VStack(spacing: 0.0) {
+                Text("CatchUp")
+                    .font(.system(size: 30.0))
+                    .fontWeight(.heavy)
+                    .padding()
+                    .padding(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                
+                Group {
+                    if let userProfile = appController.loadedUserProfile {
+                        Text("Welcome, \(userProfile.displayName)")
+                    } else {
+                        Text("Loading...")
+                    }
+                }
+                .font(.system(size: 20.0))
+                .fontWeight(.light)
+                .padding([.leading, .trailing, .bottom])
                 .padding(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            
-            if let userProfile = appController.loadedUserProfile {
-                Text(userProfile.displayName)
             }
             
         } containerContent: {
@@ -91,7 +102,15 @@ struct HomeView: View {
             }
         }
         .task {
-//            let profile = try? await UserManager.shared.getUser(userId: <#T##String#>)
+            if appController.loadedUserProfile == nil {
+                let authUserData = appController.certifyAuthStatus()
+                
+                if let userData = authUserData {
+                    let userProfile = try? await UserManager.shared.getUser(userId: userData.uid)
+                    appController.loadedUserProfile = userProfile
+                }
+            }
+            
             
             //FIXME: use stuff from DB here
             viewModel.currWeek = viewModel.getWeekRange(offset: 0)

--- a/Team10_JournalApp/Views/Home/HomeView.swift
+++ b/Team10_JournalApp/Views/Home/HomeView.swift
@@ -90,7 +90,9 @@ struct HomeView: View {
                 
             }
         }
-        .onAppear {
+        .task {
+//            let profile = try? await UserManager.shared.getUser(userId: <#T##String#>)
+            
             //FIXME: use stuff from DB here
             viewModel.currWeek = viewModel.getWeekRange(offset: 0)
             

--- a/Team10_JournalApp/Views/Home/HomeView.swift
+++ b/Team10_JournalApp/Views/Home/HomeView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct HomeView: View {
+    @ObservedObject var appController: AppViewController
     @StateObject var viewModel = HomeViewModel()
     
     var body: some View {
@@ -18,6 +19,10 @@ struct HomeView: View {
                 .padding()
                 .padding(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            
+            if let userProfile = appController.loadedUserProfile {
+                Text(userProfile.displayName)
+            }
             
         } containerContent: {
             VStack {

--- a/Team10_JournalApp/Views/Login/SignInView.swift
+++ b/Team10_JournalApp/Views/Login/SignInView.swift
@@ -87,7 +87,8 @@ struct SignInView: View {
                         let emptyFields = viewModel.email.isEmpty || viewModel.password.isEmpty
                         
                         Button(action: {
-                            viewModel.signIn {
+                            viewModel.signIn { userProfile in
+                                self.appController.loadedUserProfile = userProfile
                                 self.appController.loggedIn = true
                             }
                         }) {

--- a/Team10_JournalApp/Views/Login/SignUpView.swift
+++ b/Team10_JournalApp/Views/Login/SignUpView.swift
@@ -117,7 +117,8 @@ struct SignUpView: View {
                             }
                             
                             Button(action: {
-                                viewModel.signUp {
+                                viewModel.signUp { newUser in
+                                    self.appController.loadedUserProfile = newUser
                                     self.appController.loggedIn = true
                                 }
                             }) {

--- a/Team10_JournalApp/Views/Settings/SettingView.swift
+++ b/Team10_JournalApp/Views/Settings/SettingView.swift
@@ -72,6 +72,7 @@ struct SettingView: View {
                                         Button("No") { }
                                         Button("Yes") {
                                             viewModel.signOut {
+                                                self.appController.loadedUserProfile = nil
                                                 self.appController.viewSignUpFlag = false
                                                 self.appController.loggedIn = false
                                             }


### PR DESCRIPTION
__Implemented:__
- UserManager singleton to handle firebase firestore connections for `users` collection
- creating the new user's profile in firestore db and loading the profile into the app once the user successfully signs up
- fetching the user's profile from firestore and loading it into the app view once user signs in
- fetching and loading the user's profile from firestore if the user had already signed in previously (i.e. if the user closed the app without signing out, thus the app loads in an already signed in state)
- Displays the user's `displayName` on the home page

__Important Notes:__
- `addFriend` and `removeFriend` have been implemented in `UserManager` but are unused in this feature, they will need to be utilized when Journals collections and ability to find/add/remove friends is implemented on the views.
- a `searchUserByEmail` will need to be implemented to properly allow users to search for friends to add
- an option in settings to set the users `displayName` will be needed (`updateUserDisplayName` is implemented in manager but is not yet utilized within the app)

__Screenshots:__
![image](https://github.com/user-attachments/assets/ad920db8-ace8-4069-bd02-4080e1acac67)
